### PR TITLE
[DO-1574] Bubbling up renderstatus

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -353,106 +353,6 @@
 			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
-			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
-		},
-		{
 			"ImportPath": "k8s.io/client-go/discovery",
 			"Comment": "v2.0.0",
 			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
@@ -1076,10 +976,6 @@
 			"ImportPath": "k8s.io/client-go/transport",
 			"Comment": "v2.0.0",
 			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
-		},
-		{
-			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,7 +2,20 @@
 	"ImportPath": "github.com/goeuro/kubernetes-ingressify",
 	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
+		{
+			"ImportPath": "cloud.google.com/go/compute/metadata",
+			"Comment": "v0.1.0-115-g3b1ae45",
+			"Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
+		},
+		{
+			"ImportPath": "cloud.google.com/go/internal",
+			"Comment": "v0.1.0-115-g3b1ae45",
+			"Rev": "3b1ae45394a234c385be014e9a488f2bb6eef821"
+		},
 		{
 			"ImportPath": "github.com/Masterminds/semver",
 			"Comment": "v1.4.0",
@@ -33,24 +46,73 @@
 			"Rev": "0296d6eb16bb28f8a0c55668affcf4876dc269be"
 		},
 		{
+			"ImportPath": "github.com/blang/semver",
+			"Comment": "v3.0.1",
+			"Rev": "31b736133b98f26d5e078ec9eb591666edfd091f"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/http",
+			"Rev": "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/jose",
+			"Rev": "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/key",
+			"Rev": "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/oauth2",
+			"Rev": "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d"
+		},
+		{
+			"ImportPath": "github.com/coreos/go-oidc/oidc",
+			"Rev": "5644a2f50e2d2d5ba0b474bc5bc55fea1925936d"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/health",
+			"Comment": "v2-8-gfa29b1d",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/httputil",
+			"Comment": "v2-8-gfa29b1d",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
+			"ImportPath": "github.com/coreos/pkg/timeutil",
+			"Comment": "v2-8-gfa29b1d",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
-			"Comment": "v1.1.0-1-g782f496",
-			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
+			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/digest",
+			"Comment": "v2.4.0-rc.1-38-gcd27f179",
+			"Rev": "cd27f179f2c10c5d300e6d09025b538c475b0d51"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/reference",
+			"Comment": "v2.4.0-rc.1-38-gcd27f179",
+			"Rev": "cd27f179f2c10c5d300e6d09025b538c475b0d51"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "2.2.0-4-gff4f55a",
-			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
-		},
-		{
-			"ImportPath": "github.com/emicklei/go-restful-swagger12",
-			"Comment": "1.0.1",
-			"Rev": "dcef7f55730566d41eae5db10e7d6981829720f6"
+			"Comment": "v1.2-79-g89ef8af",
+			"Rev": "89ef8af493ab468a45a42bb0d89a06fccdd2fb22"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful/log",
-			"Comment": "2.2.0-4-gff4f55a",
-			"Rev": "ff4f55a206334ef123e4f79bbf348980da81ca46"
+			"Comment": "v1.2-79-g89ef8af",
+			"Rev": "89ef8af493ab468a45a42bb0d89a06fccdd2fb22"
+		},
+		{
+			"ImportPath": "github.com/emicklei/go-restful/swagger",
+			"Comment": "v1.2-79-g89ef8af",
+			"Rev": "89ef8af493ab468a45a42bb0d89a06fccdd2fb22"
 		},
 		{
 			"ImportPath": "github.com/ghodss/yaml",
@@ -74,13 +136,13 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.4-3-gc0656edd",
-			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+			"Comment": "v0.2-33-ge18d7aa8",
+			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Comment": "v0.4-3-gc0656edd",
-			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+			"Comment": "v0.2-33-ge18d7aa8",
+			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",
@@ -88,55 +150,15 @@
 		},
 		{
 			"ImportPath": "github.com/golang/protobuf/proto",
-			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes",
-			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/any",
-			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/duration",
-			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/timestamp",
-			"Rev": "4bd1920723d7b7c925de087aa32e2187708897f7"
-		},
-		{
-			"ImportPath": "github.com/google/btree",
-			"Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
+			"Rev": "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",
-			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/OpenAPIv2",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/compiler",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/googleapis/gnostic/extensions",
-			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
-		},
-		{
-			"ImportPath": "github.com/gregjones/httpcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-		},
-		{
-			"ImportPath": "github.com/gregjones/httpcache/diskcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
+			"Rev": "bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5"
 		},
 		{
 			"ImportPath": "github.com/howeyc/gopass",
-			"Rev": "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+			"Rev": "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 		},
 		{
 			"ImportPath": "github.com/huandu/xstrings",
@@ -148,13 +170,12 @@
 			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 		},
 		{
-			"ImportPath": "github.com/json-iterator/go",
-			"Comment": "1.0.0",
-			"Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
+			"ImportPath": "github.com/jonboulle/clockwork",
+			"Rev": "72f9bd7c4e0c2a40055ab3d0f09654f730cce982"
 		},
 		{
 			"ImportPath": "github.com/juju/ratelimit",
-			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
+			"Rev": "77ed1c8a01217656d2080ad51981f6e99adaa177"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",
@@ -169,9 +190,8 @@
 			"Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 		},
 		{
-			"ImportPath": "github.com/peterbourgon/diskv",
-			"Comment": "v2.0.1",
-			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
+			"ImportPath": "github.com/pborman/uuid",
+			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 		},
 		{
 			"ImportPath": "github.com/pkg/errors",
@@ -185,92 +205,143 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",
-			"Rev": "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+			"Rev": "5ccb023bc27df288a957c5e994cd44fd19619465"
+		},
+		{
+			"ImportPath": "github.com/ugorji/go/codec",
+			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pbkdf2",
-			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
+			"Rev": "1f22c0103821b9390939b6776727195525381532"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/scrypt",
-			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
+			"Rev": "1f22c0103821b9390939b6776727195525381532"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",
-			"Rev": "81e90905daefcd6fd217b62423c0908922eadb30"
+			"Rev": "1f22c0103821b9390939b6776727195525381532"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context/ctxhttp",
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 		},
 		{
 			"ImportPath": "golang.org/x/net/http2",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 		},
 		{
 			"ImportPath": "golang.org/x/net/http2/hpack",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 		},
 		{
 			"ImportPath": "golang.org/x/net/idna",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
 		},
 		{
 			"ImportPath": "golang.org/x/net/lex/httplex",
-			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
+			"Rev": "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2",
+			"Rev": "3c3a985cb79f52a3190fbc056984415ca6763d01"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/google",
+			"Rev": "3c3a985cb79f52a3190fbc056984415ca6763d01"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/internal",
+			"Rev": "3c3a985cb79f52a3190fbc056984415ca6763d01"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jws",
+			"Rev": "3c3a985cb79f52a3190fbc056984415ca6763d01"
+		},
+		{
+			"ImportPath": "golang.org/x/oauth2/jwt",
+			"Rev": "3c3a985cb79f52a3190fbc056984415ca6763d01"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
-		},
-		{
-			"ImportPath": "golang.org/x/sys/windows",
-			"Rev": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
+			"Rev": "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
 		},
 		{
 			"ImportPath": "golang.org/x/text/cases",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
-		},
-		{
-			"ImportPath": "golang.org/x/text/internal",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/internal/tag",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/language",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/runes",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/secure/bidirule",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/secure/precis",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/transform",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/unicode/bidi",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/unicode/norm",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
 			"ImportPath": "golang.org/x/text/width",
-			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+			"Rev": "2910a502d2bf9e43193af9d68ca516529614eed3"
 		},
 		{
-			"ImportPath": "gopkg.in/h2non/gock.v1",
-			"Comment": "v1.0.6",
-			"Rev": "84d599244901620fb3eb96473eb9e50619f69b47"
+			"ImportPath": "google.golang.org/appengine",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/app_identity",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/base",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/datastore",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/log",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/modules",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
+		},
+		{
+			"ImportPath": "google.golang.org/appengine/internal/remote_api",
+			"Rev": "4f7eeb5305a4ba1966344836ba4af9996b7b4e05"
 		},
 		{
 			"ImportPath": "gopkg.in/inf.v0",
@@ -282,528 +353,733 @@
 			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 		},
 		{
-			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/authentication/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/authorization/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/batch/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/core/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/networking/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/rbac/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/storage/v1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Comment": "kubernetes-1.8.2-beta.0",
-			"Rev": "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Comment": "kubernetes-1.8.3-beta.0",
-			"Rev": "019ae5ada31de202164b118aee88ee2d14075c31"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/discovery/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/errors",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/meta",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/meta/metatypes",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/resource",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/unversioned",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/v1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/api/validation/path",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apimachinery",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apimachinery/announced",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apimachinery/registered",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/apps",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/apps/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/apps/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authentication",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authorization",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/batch",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/batch/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v2alpha1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/certificates",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/v1alpha1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/extensions",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/policy",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/policy/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/policy/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/rbac",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1alpha1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/storage",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/storage/install",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1beta1",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/auth/user",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/conversion",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/conversion/queryparams",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/fields",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/genericapiserver/openapi/common",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/labels",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer/json",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer/protobuf",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer/recognizer",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer/streaming",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/runtime/serializer/versioning",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/selection",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/third_party/forked/golang/reflect",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/third_party/forked/golang/template",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/types",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/cert",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/clock",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/errors",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/flowcontrol",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/framer",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/homedir",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/integer",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/intstr",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/json",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/jsonpath",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/labels",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/net",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/parsers",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/rand",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/runtime",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/sets",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/uuid",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/validation",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/validation/field",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/wait",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/util/yaml",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/watch",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/pkg/watch/versioned",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/oidc",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
-			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"ImportPath": "k8s.io/client-go/testing",
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/tools/reference",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/util/cert",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
-		},
-		{
-			"ImportPath": "k8s.io/client-go/util/integer",
-			"Comment": "kubernetes-1.8.1",
-			"Rev": "2ae454230481a7cb5544325e12ad7658ecccd19b"
+			"Comment": "v2.0.0",
+			"Rev": "e121606b0d09b2e1c467183ee46217fa85a6b672"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "868f2f29720b192240e18284659231b440f9cda5"
+			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		}
 	]
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 comment: false
 ignore:
-  - "core/bindata.go"
+  - "bindata.go"
+  - "test_utils.go"

--- a/data.go
+++ b/data.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"hash/fnv"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 // IngressifyRule is a denormalization of the Ingresses rules coming from k8s

--- a/data_test.go
+++ b/data_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"reflect"
 	"testing"
 )

--- a/health_check_benchmark_test.go
+++ b/health_check_benchmark_test.go
@@ -8,8 +8,7 @@ import (
 
 func init() {
 	var opsReport = make(chan *OpsStatus, 10)
-	server := buildHealthServer(opsReport, REFRESHINTERVAL, PORT)
-	go bootstrapHealthCheck(server, nil)
+	go runHealthCheckServer(opsReport, REFRESHINTERVAL, PORT)
 }
 
 func BenchmarkBootstrapHealthCheck(b *testing.B) {

--- a/health_check_benchmark_test.go
+++ b/health_check_benchmark_test.go
@@ -8,8 +8,8 @@ import (
 
 func init() {
 	var opsReport = make(chan *OpsStatus, 10)
-	server := buildHealthServer(opsReport, REFRESH_INTERVAL, PORT)
-	go BootstrapHealthCheck(server, nil)
+	server := buildHealthServer(opsReport, REFRESHINTERVAL, PORT)
+	go bootstrapHealthCheck(server, nil)
 }
 
 func BenchmarkBootstrapHealthCheck(b *testing.B) {

--- a/health_check_benchmark_test.go
+++ b/health_check_benchmark_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func init() {
+	var opsReport = make(chan *OpsStatus, 10)
+	server := buildHealthServer(opsReport, REFRESH_INTERVAL, PORT)
+	go BootstrapHealthCheck(server, nil)
+}
+
+func BenchmarkBootstrapHealthCheck(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		http.Get(fmt.Sprintf("http://localhost:%d/health", PORT))
+	}
+}

--- a/k8s.go
+++ b/k8s.go
@@ -3,10 +3,10 @@ package main
 import (
 	"fmt"
 	"github.com/apex/log"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // GetKubeClient creates a k8s client
@@ -32,7 +32,7 @@ func ScrapeIngresses(client kubernetes.Interface, namespace string) (*v1beta1.In
 	}
 	log.Infof(nslog)
 	ingressClient := client.ExtensionsV1beta1().Ingresses(namespace)
-	list, err := ingressClient.List(metav1.ListOptions{})
+	list, err := ingressClient.List(v1.ListOptions{})
 	if err != nil {
 		log.WithError(err).Error("Failed to get list of ingresses rules")
 		return nil, err

--- a/k8s.go
+++ b/k8s.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 // GetKubeClient creates a k8s client
@@ -22,7 +23,7 @@ func GetKubeClient(configfile string) (*kubernetes.Clientset, error) {
 }
 
 // ScrapeIngresses connects to k8s and retrieves ingresses rules for all the namespaces
-func ScrapeIngresses(client kubernetes.Interface, namespace string) ([]IngressifyRule, error) {
+func ScrapeIngresses(client kubernetes.Interface, namespace string) (*v1beta1.IngressList, error) {
 	var nslog string
 	if namespace == "" {
 		nslog = "Fetching Ingress rules on all namespaces"
@@ -36,5 +37,5 @@ func ScrapeIngresses(client kubernetes.Interface, namespace string) ([]Ingressif
 		log.WithError(err).Error("Failed to get list of ingresses rules")
 		return nil, err
 	}
-	return ToIngressifyRule(list), nil
+	return list, nil
 }

--- a/k8s_test.go
+++ b/k8s_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestScrapeIngressesForAllNamespaces(t *testing.T) {
+	rules := generateRules("./examples/ingressList.json")
+	client := fake.NewSimpleClientset(&rules)
+	irules, err := ScrapeIngresses(client, "")
+	if err != nil {
+		t.Errorf("Something went wrong scraping ingress for rules: %s\n", err)
+		return
+	}
+	if irules.Size() != 2 {
+		t.Errorf("Didn't scrape all rules, got: %d, expected: %d ", irules.Size(), 2)
+	}
+}

--- a/k8s_test.go
+++ b/k8s_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"k8s.io/client-go/kubernetes/fake"
+	"testing"
 )
 
 func TestScrapeIngressesForAllNamespaces(t *testing.T) {
@@ -13,7 +13,20 @@ func TestScrapeIngressesForAllNamespaces(t *testing.T) {
 		t.Errorf("Something went wrong scraping ingress for rules: %s\n", err)
 		return
 	}
-	if irules.Size() != 2 {
+	if len(irules.Items) != 2 {
+		t.Errorf("Didn't scrape all rules, got: %d, expected: %d ", irules.Size(), 2)
+	}
+}
+
+func TestScrapeIngressesForAGivenNamespace(t *testing.T) {
+	rules := generateRules("./examples/ingressList.json")
+	client := fake.NewSimpleClientset(&rules)
+	irules, err := ScrapeIngresses(client, "ns1")
+	if err != nil {
+		t.Errorf("Something went wrong scraping ingress for rules: %s\n", err)
+		return
+	}
+	if len(irules.Items) != 1 {
 		t.Errorf("Didn't scrape all rules, got: %d, expected: %d ", irules.Size(), 2)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	config := ReadConfig(*configPath)
 
 	renderReport := make(chan OpsStatus, 10)
+	defer close(renderReport)
 
 	go bootstrapHealthCheck(config.HealthCheckPort, renderReport)
 

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func createHealthResponse(lastReport OpsStatus, writer http.ResponseWriter) {
 	}
 }
 
-// OpsStatus holds information to track failures/success on render function
+// OpsStatus holds information to track failures/success of render and execHooks functions
 // this information gets bubbled up to the health check.
 type OpsStatus struct {
 	isSuccess bool

--- a/main.go
+++ b/main.go
@@ -85,13 +85,13 @@ func main() {
 			}
 			opsStatus <- &OpsStatus{isSuccess: true, timestamp: time.Now()}
 			select {
-				case <-mainExit:
-					log.Info("Gracefully shutting down...")
-					log.Info("Waiting for server to shutdown...")
-					time.Sleep(5 * time.Second)
-					return
-				default:
-					continue
+			case <-mainExit:
+				log.Info("Gracefully shutting down...")
+				log.Info("Waiting for server to shutdown...")
+				time.Sleep(5 * time.Second)
+				return
+			default:
+				continue
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func execHooks(config Config, renderReport chan<- OpsStatus) {
 
 func render(outPath string, clientset *kubernetes.Clientset, tmpl *template.Template, renderReport chan<- OpsStatus) error {
 	irules, err := ScrapeIngresses(clientset, "")
-	cxt := ICxt{IngRules: irules}
+	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, outPath, cxt)
 	if err != nil {
 		renderReport <- OpsStatus{isSuccess: false, error: err}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -27,7 +28,9 @@ func main() {
 
 	config := ReadConfig(*configPath)
 
-	go bootstrapHealthCheck(config.HealthCheckPort)
+	renderReport := make(chan RenderStatus, 10)
+
+	go bootstrapHealthCheck(config.HealthCheckPort, renderReport)
 
 	fmap := template.FuncMap{
 		"GroupByHost": GroupByHost,
@@ -53,17 +56,25 @@ func main() {
 	}
 
 	if *dryRun {
-		render(config, clientset, tmpl, false)
+		render(config, clientset, tmpl, false, renderReport)
 	} else {
 		for range time.NewTicker(duration).C {
-			render(config, clientset, tmpl, true)
+			render(config, clientset, tmpl, true, renderReport)
 		}
 	}
 }
 
-func bootstrapHealthCheck(port uint32) {
+func bootstrapHealthCheck(port uint32, hookStatus <-chan RenderStatus) {
+	lastReport := RenderStatus{isSuccess: true, error: nil}
 	http.HandleFunc("/health", func(writer http.ResponseWriter, request *http.Request) {
-		fmt.Fprintf(writer, "I am alive !\n")
+		lastReport.mux.Lock()
+		select {
+		case lastReport = <-hookStatus:
+			createHealthResponse(lastReport, writer)
+		default:
+			createHealthResponse(lastReport, writer)
+		}
+		lastReport.mux.Unlock()
 	})
 	err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {
@@ -72,12 +83,32 @@ func bootstrapHealthCheck(port uint32) {
 	}
 }
 
-func render(config Config, clientset *kubernetes.Clientset, tmpl *template.Template, withHooks bool) {
+func createHealthResponse(lastReport RenderStatus, writer http.ResponseWriter) {
+	if lastReport.isSuccess {
+		fmt.Fprintf(writer, "Healthy !\n")
+		writer.WriteHeader(http.StatusOK)
+	} else {
+		fmt.Fprintf(writer, "Unhealthy: %s !\n", lastReport.error)
+		writer.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+// RenderStatus holds information to track failures/success on render function
+// this information gets bubbled up to the health check.
+type RenderStatus struct {
+	isSuccess bool
+	error     error
+	mux       sync.Mutex
+}
+
+func render(config Config, clientset *kubernetes.Clientset, tmpl *template.Template, withHooks bool,
+	renderReport chan<- RenderStatus) {
 	irules, err := ScrapeIngresses(clientset, "")
 	cxt := ICxt{IngRules: irules}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
 	if err != nil {
 		log.WithError(err).Error("Failed to render template")
+		renderReport <- RenderStatus{isSuccess: false, error: err}
 		return
 	}
 	if withHooks {
@@ -85,9 +116,11 @@ func render(config Config, clientset *kubernetes.Clientset, tmpl *template.Templ
 		out, err := ExecHook(config.Hooks.PostRender)
 		if err != nil {
 			log.WithError(err).Error("Failed to run post hook")
+			renderReport <- RenderStatus{isSuccess: false, error: err}
 			return
 		}
 		log.Info("Output from post hook")
 		fmt.Println(out)
+		renderReport <- RenderStatus{isSuccess: true, error: nil}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -55,10 +55,10 @@ func main() {
 		return
 	}
 
-	go func() {
-		if *dryRun {
-			render(config.OutTemplate, clientset, tmpl)
-		} else {
+	if *dryRun {
+		render(config.OutTemplate, clientset, tmpl)
+	} else {
+		go func() {
 			for range time.NewTicker(duration).C {
 				err = render(config.OutTemplate, clientset, tmpl)
 				if err != nil {
@@ -73,9 +73,9 @@ func main() {
 				}
 				opsStatus <- &OpsStatus{isSuccess: true, timestamp: time.Now()}
 			}
-		}
-	}()
-	log.WithError(runHealthCheckServer(opsStatus, duration, config.HealthCheckPort)).Error("Health server is down...")
+		}()
+		log.WithError(runHealthCheckServer(opsStatus, duration, config.HealthCheckPort)).Error("Health server is down...")
+	}
 }
 
 func runHealthCheckServer(status chan *OpsStatus, duration time.Duration, port uint32) error {

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,0 @@
-package main
-
-import (
-	"testing"
-)
-
-func Test(t *testing.T) {
-}

--- a/main_test.go
+++ b/main_test.go
@@ -10,10 +10,10 @@ import (
 	"time"
 )
 
-func handlerBuilder() HealthHandler {
+func handlerBuilder() healthHandler {
 	var opsReport = make(chan *OpsStatus, 10)
 	defaultReport := OpsStatus{isSuccess: true, timestamp: time.Now()}
-	hhandler := HealthHandler{opsStatus: opsReport, cacheExpirationTime: REFRESH_INTERVAL, lastReport: &defaultReport}
+	hhandler := healthHandler{opsStatus: opsReport, cacheExpirationTime: REFRESHINTERVAL, lastReport: &defaultReport}
 	return hhandler
 }
 
@@ -32,7 +32,7 @@ func TestBootstrapHealthCheck_should_return_500_when_cache_has_expired(t *testin
 	r, _ := http.NewRequest("GET", "/health", nil)
 	w := httptest.NewRecorder()
 	hhandler.ServeHTTP(w, r)
-	time.Sleep(REFRESH_INTERVAL) //sleep interval so the cache expires
+	time.Sleep(REFRESHINTERVAL) //sleep interval so the cache expires
 	r, _ = http.NewRequest("GET", "/health", nil)
 	w = httptest.NewRecorder()
 	hhandler.ServeHTTP(w, r)
@@ -111,7 +111,7 @@ func TestBootstrapHealthCheck_should_not_return_cache_after_report_and_cache_exp
 	if string(body) != expectedBody {
 		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
 	}
-	time.Sleep(REFRESH_INTERVAL)
+	time.Sleep(REFRESHINTERVAL)
 	// call again without making report should give us the last response again
 	r, _ = http.NewRequest("GET", "/health", nil)
 	w = httptest.NewRecorder()

--- a/main_test.go
+++ b/main_test.go
@@ -112,7 +112,7 @@ func TestBootstrapHealthCheck_should_not_return_cache_after_report_and_cache_exp
 		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
 	}
 	time.Sleep(REFRESHINTERVAL)
-	// call again without making report should give us the last response again
+	// call again without making report should gives us an error since cache expired
 	r, _ = http.NewRequest("GET", "/health", nil)
 	w = httptest.NewRecorder()
 	hhandler.ServeHTTP(w, r)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func handlerBuilder() HealthHandler {
+	var opsReport = make(chan *OpsStatus, 10)
+	defaultReport := OpsStatus{isSuccess: true, timestamp: time.Now()}
+	hhandler := HealthHandler{opsStatus: opsReport, cacheExpirationTime: REFRESH_INTERVAL, lastReport: &defaultReport}
+	return hhandler
+}
+
+func TestBootstrapHealthCheck_should_return_initial_cache_when_no_report(t *testing.T) {
+	hhandler := handlerBuilder()
+	r, _ := http.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Errorf("wrong code returned")
+	}
+}
+
+func TestBootstrapHealthCheck_should_return_500_when_cache_has_expired(t *testing.T) {
+	hhandler := handlerBuilder()
+	r, _ := http.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	time.Sleep(REFRESH_INTERVAL) //sleep interval so the cache expires
+	r, _ = http.NewRequest("GET", "/health", nil)
+	w = httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	if w.Code != 500 {
+		t.Errorf("Should return 500 when cache has expired, got: %d, expected %d", w.Code, 500)
+	}
+}
+
+func TestBootstrapHealthCheck_should_not_return_cache_when_reporting_ops(t *testing.T) {
+	hhandler := handlerBuilder()
+	statusError := OpsStatus{isSuccess: false, timestamp: time.Now(), error: errors.New("This one failed")}
+	hhandler.opsStatus <- &statusError
+	r, _ := http.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	if w.Code != 500 {
+		t.Errorf("Should return 500 from the published status error, got: %d, expected %d", w.Code, 500)
+	}
+	body, err := ioutil.ReadAll(w.Body)
+	if err != nil {
+		t.Errorf("Should return non empty body. Something went wrong: %s", err)
+	}
+	expectedBody := fmt.Sprintf("Unhealthy: %s !\n", statusError.error)
+	if string(body) != expectedBody {
+		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
+	}
+}
+
+func TestBootstrapHealthCheck_should_return_last_report_as_cache_when_no_report(t *testing.T) {
+	hhandler := handlerBuilder()
+	statusError := OpsStatus{isSuccess: false, timestamp: time.Now(), error: errors.New("This one failed")}
+	hhandler.opsStatus <- &statusError
+	r, _ := http.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	if w.Code != 500 {
+		t.Errorf("Should return 500 from the published status error, got: %d, expected %d", w.Code, 500)
+	}
+	body, err := ioutil.ReadAll(w.Body)
+	if err != nil {
+		t.Errorf("Should return non empty body. Something went wrong: %s", err)
+	}
+	expectedBody := fmt.Sprintf("Unhealthy: %s !\n", statusError.error)
+	if string(body) != expectedBody {
+		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
+	}
+	// call again without making report should give us the last response again
+	r, _ = http.NewRequest("GET", "/health", nil)
+	w = httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	body, err = ioutil.ReadAll(w.Body)
+	if err != nil {
+		t.Errorf("Should return 500 when cache has expired, got: %d, expected %d", w.Code, 500)
+	}
+	expectedBody = fmt.Sprintf("Unhealthy: %s !\n", statusError.error)
+	if string(body) != expectedBody {
+		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
+	}
+}
+
+func TestBootstrapHealthCheck_should_not_return_cache_after_report_and_cache_expiration(t *testing.T) {
+	hhandler := handlerBuilder()
+	statusError := OpsStatus{isSuccess: false, timestamp: time.Now(), error: errors.New("This one failed")}
+	hhandler.opsStatus <- &statusError
+	r, _ := http.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	if w.Code != 500 {
+		t.Errorf("Should return 500 from the published status error, got: %d, expected %d", w.Code, 500)
+	}
+	body, err := ioutil.ReadAll(w.Body)
+	if err != nil {
+		t.Errorf("Should return non empty body. Something went wrong: %s", err)
+	}
+	expectedBody := fmt.Sprintf("Unhealthy: %s !\n", statusError.error)
+	if string(body) != expectedBody {
+		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
+	}
+	time.Sleep(REFRESH_INTERVAL)
+	// call again without making report should give us the last response again
+	r, _ = http.NewRequest("GET", "/health", nil)
+	w = httptest.NewRecorder()
+	hhandler.ServeHTTP(w, r)
+	body, err = ioutil.ReadAll(w.Body)
+	if err != nil {
+		t.Errorf("Should return 500 when cache has expired, got: %d, expected %d", w.Code, 500)
+	}
+	expectedBody = fmt.Sprintf("Unhealthy: %s !\n", statusError.error)
+	if string(body) == expectedBody {
+		t.Errorf("Body is wrong, got: %s, expected: %s", string(body), expectedBody)
+	}
+}

--- a/render_test.go
+++ b/render_test.go
@@ -29,7 +29,7 @@ func runRenderFor(router string) (actual string, expected string) {
 		panic(err)
 	}
 
-	cxt := ICxt{IngRules: irules}
+	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
 
 	actualRes, err := ioutil.ReadFile(fmt.Sprintf("/tmp/%s.actual", router))

--- a/template.go
+++ b/template.go
@@ -39,6 +39,7 @@ func PrepareTemplate(tmplpath string, withfuncs template.FuncMap) (*template.Tem
 // RenderTemplate renders the template and writes the output to `outpath`
 func RenderTemplate(tmpl *template.Template, outpath string, cxt ICxt) error {
 	output, err := os.Create(outpath)
+	defer output.Close()
 	if err != nil {
 		log.WithError(err).Error("Failed to render template")
 		return err

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,0 +1,8 @@
+package main
+
+import "time"
+
+const (
+	PORT             uint32 = 9595
+	REFRESH_INTERVAL        = 3 * time.Second
+)

--- a/test_utils.go
+++ b/test_utils.go
@@ -3,6 +3,8 @@ package main
 import "time"
 
 const (
-	PORT             uint32 = 9595
-	REFRESH_INTERVAL        = 3 * time.Second
+	// PORT is the port
+	PORT uint32 = 9595
+	// REFRESHINTERVAL is the cache expiration time in seconds
+	REFRESHINTERVAL = 3 * time.Second
 )


### PR DESCRIPTION
**Problem statement**

`render` and `execHooks` functions has two possible failure scenarios (respectively): 

1. Fail to render template
2. Execution of hooks fail. 

and we need to communicate this failures through our http health endpoint when any of those happen. 

**Proposal**

We leverage channel communication and the producers are: `render` and `execHooks` whereas  the consumer is the http health endpoint. 
A few considerations about the channel communication:

1. Channels are buffered, meaning there's room for more than one render-status to be pushed to the channel. This way we *try* to avoid producers getting blocked to push messages. Producer could get blocked in case Haproxy stops calling the health endpoint and the channel exceeds its quota of 10 messages, but at this point is probable that HAproxy is not even up at all so we don't bother unblocking the render function. 
2. Health response keeps a cache of the `last-report` read on the channel in case there's no new events and returns inmediately. Since this cache is used by the http Handler function we use a Mutex to protect read/writes to this cache variable.

