### PR TITLE
ordering by asc path len

### DIFF
--- a/data.go
+++ b/data.go
@@ -66,12 +66,16 @@ func (ir IngRules) Swap(i, j int) {
 }
 
 func (ir IngRules) Less(i, j int) bool {
-	return (len(ir[i].Path) > len(ir[j].Path))
+	return (len(ir[i].Path) < len(ir[j].Path))
 }
 
-// OrderAscByPathLen order the rules by Path length in ascending order
-func OrderAscByPathLen(rules []IngressifyRule) []IngressifyRule {
-	sort.Sort(IngRules(rules))
+// OrderByPathLen order the rules by Path length in ascending or descending order
+func OrderByPathLen(rules []IngressifyRule, asc bool) []IngressifyRule {
+	if asc {
+		sort.Sort(sort.Reverse(IngRules(rules)))
+	} else {
+		sort.Sort(IngRules(rules))
+	}
 	return rules
 }
 

--- a/data.go
+++ b/data.go
@@ -69,7 +69,7 @@ func (ir IngRules) Less(i, j int) bool {
 	return (len(ir[i].Path) > len(ir[j].Path))
 }
 
-// Orders the rules by Path length
+// OrderAscByPathLen order the rules by Path length in ascending order
 func OrderAscByPathLen(rules []IngressifyRule) []IngressifyRule {
 	sort.Sort(IngRules(rules))
 	return rules

--- a/data.go
+++ b/data.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"sort"
 )
 
 // IngressifyRule is a denormalization of the Ingresses rules coming from k8s
@@ -51,6 +52,27 @@ func ToIngressifyRule(il *v1beta1.IngressList) []IngressifyRule {
 		}
 	}
 	return ifyrules
+}
+
+// IngRules is just an alias to be able to implement custom sorting.
+type IngRules []IngressifyRule
+
+func (ir IngRules) Len() int {
+	return len(ir)
+}
+
+func (ir IngRules) Swap(i, j int) {
+	ir[i], ir[j] = ir[j], ir[i]
+}
+
+func (ir IngRules) Less(i, j int) bool {
+	return (len(ir[i].Path) > len(ir[j].Path))
+}
+
+// Orders the rules by Path length
+func OrderAscByPathLen(rules []IngressifyRule) []IngressifyRule {
+	sort.Sort(IngRules(rules))
+	return rules
 }
 
 // GroupByHost returns a map of IngressifyRule grouped by ir.Host

--- a/data_test.go
+++ b/data_test.go
@@ -151,6 +151,17 @@ func TestGroupByServiceName(t *testing.T) {
 	}
 }
 
+func TestOrderByPathLength(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	ordered := OrderAscByPathLen(ingressifyRules)
+	for i := 0; i < len(ordered)-1; i++ {
+		if len(ordered[i].Path) < len(ordered[i+1].Path) {
+			t.Errorf("Paths are not in ascending order, got: len(%s) < len(%s)", ordered[i].Path, ordered[i+1].Path)
+		}
+	}
+}
+
 func isIngressifyRulePresent(ir IngressifyRule, irs []IngressifyRule) bool {
 	for _, r := range irs {
 		if ir.Namespace == r.Namespace && ir.Name == r.Name && ir.ServicePort == r.ServicePort &&

--- a/data_test.go
+++ b/data_test.go
@@ -151,13 +151,24 @@ func TestGroupByServiceName(t *testing.T) {
 	}
 }
 
-func TestOrderByPathLength(t *testing.T) {
+func TestOrderByPathLengthAsc(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	ordered := OrderAscByPathLen(ingressifyRules)
+	ordered := OrderByPathLen(ingressifyRules, true)
 	for i := 0; i < len(ordered)-1; i++ {
 		if len(ordered[i].Path) < len(ordered[i+1].Path) {
 			t.Errorf("Paths are not in ascending order, got: len(%s) < len(%s)", ordered[i].Path, ordered[i+1].Path)
+		}
+	}
+}
+
+func TestOrderByPathLengthDesc(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	ordered := OrderByPathLen(ingressifyRules, false)
+	for i := 0; i < len(ordered)-1; i++ {
+		if len(ordered[i].Path) > len(ordered[i+1].Path) {
+			t.Errorf("Paths are not in descending order, got: len(%s) > len(%s)", ordered[i].Path, ordered[i+1].Path)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -40,10 +40,10 @@ func main() {
 	}
 
 	fmap := template.FuncMap{
-		"GroupByHost":       GroupByHost,
-		"GroupByPath":       GroupByPath,
-		"GroupBySvcNs":      GroupBySvcNs,
-		"OrderAscByPathLen": OrderAscByPathLen,
+		"GroupByHost":    GroupByHost,
+		"GroupByPath":    GroupByPath,
+		"GroupBySvcNs":   GroupBySvcNs,
+		"OrderByPathLen": OrderByPathLen,
 	}
 
 	clientset, err := GetKubeClient(config.Kubeconfig)

--- a/main.go
+++ b/main.go
@@ -40,9 +40,10 @@ func main() {
 	}
 
 	fmap := template.FuncMap{
-		"GroupByHost":  GroupByHost,
-		"GroupByPath":  GroupByPath,
-		"GroupBySvcNs": GroupBySvcNs,
+		"GroupByHost":       GroupByHost,
+		"GroupByPath":       GroupByPath,
+		"GroupBySvcNs":      GroupBySvcNs,
+		"OrderAscByPathLen": OrderAscByPathLen,
 	}
 
 	clientset, err := GetKubeClient(config.Kubeconfig)


### PR DESCRIPTION
We add a new function `OrderAscByPathLen` available at runtime to order IngressifyRules by longest path. This will allow http load balancers to do matching on longest path first. This could avoid situations like: 
```
path_beg -i /aaa/b/
path_beg -i /aaa/b/c/
```

when calling `GET /aaa/b/c/`  the first rule will match and the request will be possibly routed to the wrong backend, on the other hand an order like:

```
path_beg -i /aaa/b/c/
path_beg -i /aaa/b/
```

guarantees a longest match first and finally `GET /aaa/b/` won't match the first rule but the second.
  