### PR TITLE
fixes as per running golang vet

### DIFF
--- a/data.go
+++ b/data.go
@@ -3,7 +3,6 @@ package main
 import (
 	"hash/fnv"
 	"reflect"
-	"sort"
 	"strings"
 
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"

--- a/data.go
+++ b/data.go
@@ -3,6 +3,7 @@ package main
 import (
 	"hash/fnv"
 	"reflect"
+	"sort"
 	"strings"
 
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"

--- a/data_test.go
+++ b/data_test.go
@@ -29,6 +29,9 @@ func (f Set) IsMember(x string) bool {
 
 func generateRules(from string) v1beta1.IngressList {
 	test, err := ioutil.ReadFile(from)
+	if err != nil {
+		panic(err)
+	}
 	il := v1beta1.IngressList{}
 	err = json.Unmarshal(test, &il)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ type healthHandler struct {
 	sync.Mutex
 }
 
-func (hh healthHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+func (hh *healthHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	hh.Lock()
 	select {
 	case currentReport := <-hh.opsStatus:
@@ -143,6 +143,9 @@ func execHooks(config Config, renderReport chan<- *OpsStatus) error {
 
 func render(outPath string, clientset *kubernetes.Clientset, tmpl *template.Template) error {
 	irules, err := ScrapeIngresses(clientset, "")
+	if err != nil {
+		return err
+	}
 	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, outPath, cxt)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,18 +2,19 @@ package main
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
-func handlerBuilder() healthHandler {
+func handlerBuilder() *healthHandler {
 	var opsReport = make(chan *OpsStatus, 10)
 	defaultReport := OpsStatus{isSuccess: true, timestamp: time.Now()}
-	hhandler := healthHandler{opsStatus: opsReport, cacheExpirationTime: REFRESHINTERVAL, lastReport: &defaultReport}
+	hhandler := &healthHandler{opsStatus: opsReport, cacheExpirationTime: REFRESHINTERVAL, lastReport: &defaultReport}
 	return hhandler
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/Masterminds/sprig"
 	"html/template"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes/fake"
 	"testing"
+
+	"github.com/Masterminds/sprig"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func runRenderFor(router string) (actual string, expected string) {
@@ -31,6 +32,9 @@ func runRenderFor(router string) (actual string, expected string) {
 
 	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
+	if err != nil {
+		panic(err)
+	}
 
 	actualRes, err := ioutil.ReadFile(fmt.Sprintf("/tmp/%s.actual", router))
 	if err != nil {


### PR DESCRIPTION
Just installed goplus on atom and found out that includes [golang vet tool](https://golang.org/cmd/vet/) that tries to check for common golang bugs that the compiler can't detect. One of those that caught my attention was about passing a lock by value and not by reference. According to [this article](https://medium.com/golangspec/detect-locks-passed-by-value-in-go-efb4ac9a3f2b) this can cause a deadlock 😨 