### PR TITLE
turn everything into generic

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -56,7 +56,7 @@ func TestToIngressifyRule(t *testing.T) {
 func TestGroupByHost(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	byHost := GroupByHost(ingressifyRules)
+	byHost := GroupByHost(ToGeneric(ingressifyRules))
 	// All hosts are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := byHost[r.Host]; !ok {
@@ -78,7 +78,7 @@ func TestGroupByHost(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := byHost[r.Host]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -88,7 +88,7 @@ func TestGroupByHost(t *testing.T) {
 func TestGroupByPath(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	byPath := GroupByPath(ingressifyRules)
+	byPath := GroupByPath(ToGeneric(ingressifyRules))
 	// All paths are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := byPath[r.Path]; !ok {
@@ -110,7 +110,7 @@ func TestGroupByPath(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := byPath[r.Path]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -120,7 +120,7 @@ func TestGroupByPath(t *testing.T) {
 func TestGroupByServiceName(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	bySvcNs := GroupBySvcNs(ingressifyRules)
+	bySvcNs := GroupBySvcNs(ToGeneric(ingressifyRules))
 	// All paths are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := bySvcNs[r.ServiceName+"-"+r.Namespace]; !ok {
@@ -147,7 +147,7 @@ func TestGroupByServiceName(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := bySvcNs[r.ServiceName+"-"+r.Namespace]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -157,7 +157,7 @@ func TestGroupByServiceName(t *testing.T) {
 func TestOrderByPathLengthAsc(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	ordered := OrderByPathLen(ingressifyRules, true)
+	ordered := FromGeneric(OrderByPathLen(ToGeneric(ingressifyRules), true))
 	for i := 0; i < len(ordered)-1; i++ {
 		if len(ordered[i].Path) < len(ordered[i+1].Path) {
 			t.Errorf("Paths are not in ascending order, got: len(%s) < len(%s)", ordered[i].Path, ordered[i+1].Path)
@@ -168,10 +168,71 @@ func TestOrderByPathLengthAsc(t *testing.T) {
 func TestOrderByPathLengthDesc(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	ordered := OrderByPathLen(ingressifyRules, false)
+	ordered := FromGeneric(OrderByPathLen(ToGeneric(ingressifyRules), false))
 	for i := 0; i < len(ordered)-1; i++ {
 		if len(ordered[i].Path) > len(ordered[i+1].Path) {
 			t.Errorf("Paths are not in descending order, got: len(%s) > len(%s)", ordered[i].Path, ordered[i+1].Path)
+		}
+	}
+}
+
+func TestFromGeneric(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	gen := make([]interface{}, len(ingressifyRules))
+	for i := range ingressifyRules {
+		gen[i] = ingressifyRules[i]
+	}
+	fromGen := FromGeneric(gen)
+	// len should be equal
+	if len(fromGen) != len(ingressifyRules) {
+		t.Errorf("Length should be equal, got: %d, expected: %d", len(fromGen), len(ingressifyRules))
+	}
+	// all rules should be the same on both arrays
+	for i := range fromGen {
+		if fromGen[i].Hash != ingressifyRules[i].Hash {
+			t.Errorf("Missing rule after applying FromGeneric, got hash: %d, expected hash: %d", ingressifyRules[i].Hash, fromGen[i].Hash)
+		}
+	}
+}
+
+func TestToGeneric(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	gen := ToGeneric(ingressifyRules)
+	// len should be equal
+	if len(gen) != len(ingressifyRules) {
+		t.Errorf("Length should be equal, got: %d, expected: %d", len(gen), len(ingressifyRules))
+	}
+	// underlying type must be IngressifyRule
+	for i := range gen {
+		if reflect.TypeOf(gen[i]) != reflect.TypeOf(ingressifyRules[i]) {
+			t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[i]), reflect.TypeOf(ingressifyRules[i]))
+		}
+	}
+}
+
+func TestToGenericMap(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	m := make(map[string][]IngressifyRule)
+	for _, k := range ingressifyRules {
+		key := string(k.Hash)
+		if _, ok := m[key]; ok {
+			m[key] = append(m[key], k)
+		} else {
+			m[key] = []IngressifyRule{k}
+		}
+	}
+	gen := ToGenericMap(m)
+	if len(gen) != len(m) {
+		t.Errorf("Maps should have the same length, got: %d, expected: %d", len(gen), len(m))
+	}
+	for k := range m {
+		for i := range gen[k] {
+			if reflect.TypeOf(gen[k][i]) != reflect.TypeOf(m[k][i]) {
+				t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[k][i]), reflect.TypeOf(m[k][i]))
+			}
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func render(outPath string, clientset *kubernetes.Clientset, tmpl *template.Temp
 	if err != nil {
 		return err
 	}
-	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
+	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
 	err = RenderTemplate(tmpl, outPath, cxt)
 	if err != nil {
 		return err

--- a/render_test.go
+++ b/render_test.go
@@ -30,7 +30,7 @@ func runRenderFor(router string) (actual string, expected string) {
 		panic(err)
 	}
 
-	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
+	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
In order to use sprig, we pass `IngressifyRules` to the template as generic `[]interface{}` . But this mean, we need to change all functions that we provide already to accept Generic. 

I think this is a bit invasive. Im in favor of just providing a helper function if you want to use Sprig functions. 

I will reference the other PR here. 