### PR TITLE
Generic conversion

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,9 +2,6 @@
 	"ImportPath": "github.com/goeuro/kubernetes-ingressify",
 	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
-	"Packages": [
-		"./..."
-	],
 	"Deps": [
 		{
 			"ImportPath": "cloud.google.com/go/compute/metadata",
@@ -210,6 +207,10 @@
 		{
 			"ImportPath": "github.com/ugorji/go/codec",
 			"Rev": "f1f1a805ed361a0e078bb537e4ea78cd37dcf065"
+		},
+		{
+			"ImportPath": "github.com/viant/toolbox",
+			"Rev": "51fd0a1a1855c0c1427ce131ddc0568bc7f15137"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/pbkdf2",

--- a/data.go
+++ b/data.go
@@ -22,8 +22,6 @@ type IngressifyRule struct {
 }
 
 // ICxt holds data used for rendering.
-// All data is turned into generic so it can be seamlessly used with Sprig
-// functions.
 type ICxt struct {
 	IngRules []IngressifyRule
 }

--- a/data.go
+++ b/data.go
@@ -25,11 +25,11 @@ type IngressifyRule struct {
 // All data is turned into generic so it can be seamlessly used with Sprig
 // functions.
 type ICxt struct {
-	IngRules []interface{}
+	IngRules []IngressifyRule
 }
 
-// ToGeneric turns an []IngressifyRule to an []interface{}
-func ToGeneric(rules []IngressifyRule) []interface{} {
+// ToSprigList turns an []IngressifyRule to an []interface{}
+func ToSprigList(rules []IngressifyRule) []interface{} {
 	a := make([]interface{}, len(rules))
 	for i := range rules {
 		a[i] = rules[i]
@@ -37,29 +37,11 @@ func ToGeneric(rules []IngressifyRule) []interface{} {
 	return a
 }
 
-// FromGeneric turns an []interface{} into an []IngressifyRule
-func FromGeneric(rules []interface{}) []IngressifyRule {
-	m := make([]IngressifyRule, len(rules))
-	for i := range rules {
-		m[i] = rules[i].(IngressifyRule)
-	}
-	return m
-}
-
-// ToGenericMap turns a map[string][]IngressifyRule to a map[string][]interface{}
-func ToGenericMap(groupedBy map[string][]IngressifyRule) map[string][]interface{} {
+// ToSprigDict turns a map[string][]IngressifyRule to a map[string][]interface{}
+func ToSprigDict(groupedBy map[string][]IngressifyRule) map[string][]interface{} {
 	m := make(map[string][]interface{})
 	for k, v := range groupedBy {
-		m[k] = ToGeneric(v)
-	}
-	return m
-}
-
-// FromGenericMap turns a map[string][]interface{} to a map[string][]IngressifyRule
-func FromGenericMap(grouped map[string][]interface{}) map[string][]IngressifyRule {
-	m := make(map[string][]IngressifyRule)
-	for k, v := range grouped {
-		m[k] = FromGeneric(v)
+		m[k] = ToSprigList(v)
 	}
 	return m
 }
@@ -108,29 +90,28 @@ func (ir IngRules) Less(i, j int) bool {
 }
 
 // OrderByPathLen order the rules by Path length in ascending or descending order
-func OrderByPathLen(rules []interface{}, asc bool) []interface{} {
-	ingRules := FromGeneric(rules)
+func OrderByPathLen(rules []IngressifyRule, asc bool) []IngressifyRule {
 	if asc {
-		sort.Sort(sort.Reverse(IngRules(ingRules)))
+		sort.Sort(sort.Reverse(IngRules(rules)))
 	} else {
-		sort.Sort(IngRules(ingRules))
+		sort.Sort(IngRules(rules))
 	}
-	return ToGeneric(ingRules)
+	return rules
 }
 
 // GroupByHost returns a map of IngressifyRule grouped by ir.Host
-func GroupByHost(rules []interface{}) map[string][]interface{} {
-	return ToGenericMap(groupByGeneric(FromGeneric(rules), "Host"))
+func GroupByHost(rules []IngressifyRule) map[string][]IngressifyRule {
+	return groupByGeneric(rules, "Host")
 }
 
 // GroupByPath returns a map of IngressifyRule grouped by ir.Path
-func GroupByPath(rules []interface{}) map[string][]interface{} {
-	return ToGenericMap(groupByGeneric(FromGeneric(rules), "Path"))
+func GroupByPath(rules []IngressifyRule) map[string][]IngressifyRule {
+	return groupByGeneric(rules, "Path")
 }
 
 // GroupBySvcNs returns a map of IngressifyRule grouped by ir.ServiceName + ir.Namespace
-func GroupBySvcNs(rules []interface{}) map[string][]interface{} {
-	return ToGenericMap(groupByGeneric(FromGeneric(rules), "ServiceName", "Namespace"))
+func GroupBySvcNs(rules []IngressifyRule) map[string][]IngressifyRule {
+	return groupByGeneric(rules, "ServiceName", "Namespace")
 }
 
 /*

--- a/data.go
+++ b/data.go
@@ -26,24 +26,6 @@ type ICxt struct {
 	IngRules []IngressifyRule
 }
 
-// ToSprigList turns an []IngressifyRule to an []interface{}
-func ToSprigList(rules []IngressifyRule) []interface{} {
-	a := make([]interface{}, len(rules))
-	for i := range rules {
-		a[i] = rules[i]
-	}
-	return a
-}
-
-// ToSprigDict turns a map[string][]IngressifyRule to a map[string][]interface{}
-func ToSprigDict(groupedBy map[string][]IngressifyRule) map[string][]interface{} {
-	m := make(map[string][]interface{})
-	for k, v := range groupedBy {
-		m[k] = ToSprigList(v)
-	}
-	return m
-}
-
 func hash(s string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(s))

--- a/data.go
+++ b/data.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	tb "github.com/viant/toolbox"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
@@ -30,6 +31,16 @@ func hash(s string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return h.Sum32()
+}
+
+// AsMap returns a generic map. Useful for Sprig functions
+func AsMap(sourceMap interface{}) map[string]interface{} {
+	return tb.AsMap(sourceMap)
+}
+
+// AsSlice returns a generic list. Useful for Sprig functions
+func AsSlice(sourceSlice interface{}) []interface{} {
+	return tb.AsSlice(sourceSlice)
 }
 
 // ToIngressifyRule converts from *v1beta1.IngressList (normalized) to IngressifyRule (denormalized)

--- a/data_test.go
+++ b/data_test.go
@@ -176,47 +176,6 @@ func TestOrderByPathLengthDesc(t *testing.T) {
 	}
 }
 
-func TestToGeneric(t *testing.T) {
-	testRules := generateRules("./examples/ingressList.json")
-	ingressifyRules := ToIngressifyRule(&testRules)
-	gen := ToSprigList(ingressifyRules)
-	// len should be equal
-	if len(gen) != len(ingressifyRules) {
-		t.Errorf("Length should be equal, got: %d, expected: %d", len(gen), len(ingressifyRules))
-	}
-	// underlying type must be IngressifyRule
-	for i := range gen {
-		if reflect.TypeOf(gen[i]) != reflect.TypeOf(ingressifyRules[i]) {
-			t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[i]), reflect.TypeOf(ingressifyRules[i]))
-		}
-	}
-}
-
-func TestToGenericMap(t *testing.T) {
-	testRules := generateRules("./examples/ingressList.json")
-	ingressifyRules := ToIngressifyRule(&testRules)
-	m := make(map[string][]IngressifyRule)
-	for _, k := range ingressifyRules {
-		key := string(k.Hash)
-		if _, ok := m[key]; ok {
-			m[key] = append(m[key], k)
-		} else {
-			m[key] = []IngressifyRule{k}
-		}
-	}
-	gen := ToSprigDict(m)
-	if len(gen) != len(m) {
-		t.Errorf("Maps should have the same length, got: %d, expected: %d", len(gen), len(m))
-	}
-	for k := range m {
-		for i := range gen[k] {
-			if reflect.TypeOf(gen[k][i]) != reflect.TypeOf(m[k][i]) {
-				t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[k][i]), reflect.TypeOf(m[k][i]))
-			}
-		}
-	}
-}
-
 func isIngressifyRulePresent(ir IngressifyRule, irs []IngressifyRule) bool {
 	for _, r := range irs {
 		if ir.Namespace == r.Namespace && ir.Name == r.Name && ir.ServicePort == r.ServicePort &&

--- a/data_test.go
+++ b/data_test.go
@@ -56,7 +56,7 @@ func TestToIngressifyRule(t *testing.T) {
 func TestGroupByHost(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	byHost := GroupByHost(ingressifyRules)
+	byHost := GroupByHost(ToGeneric(ingressifyRules))
 	// All hosts are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := byHost[r.Host]; !ok {
@@ -78,7 +78,7 @@ func TestGroupByHost(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := byHost[r.Host]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -88,7 +88,7 @@ func TestGroupByHost(t *testing.T) {
 func TestGroupByPath(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	byPath := GroupByPath(ingressifyRules)
+	byPath := GroupByPath(ToGeneric(ingressifyRules))
 	// All paths are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := byPath[r.Path]; !ok {
@@ -110,7 +110,7 @@ func TestGroupByPath(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := byPath[r.Path]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -120,7 +120,7 @@ func TestGroupByPath(t *testing.T) {
 func TestGroupByServiceName(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	bySvcNs := GroupBySvcNs(ingressifyRules)
+	bySvcNs := GroupBySvcNs(ToGeneric(ingressifyRules))
 	// All paths are in the map
 	for _, r := range ingressifyRules {
 		if _, ok := bySvcNs[r.ServiceName+"-"+r.Namespace]; !ok {
@@ -147,7 +147,7 @@ func TestGroupByServiceName(t *testing.T) {
 	// All IngressifyRules are mapped
 	for _, r := range ingressifyRules {
 		mr, _ := bySvcNs[r.ServiceName+"-"+r.Namespace]
-		if !isIngressifyRulePresent(r, mr) {
+		if !isIngressifyRulePresent(r, FromGeneric(mr)) {
 			t.Errorf("Missing rule, Name: %s, Namespace: %s, Host: %s, Path: %s, ServicePort: %d, ServiceName: %s",
 				r.Name, r.Namespace, r.Host, r.Path, r.ServicePort, r.ServiceName)
 		}
@@ -157,7 +157,7 @@ func TestGroupByServiceName(t *testing.T) {
 func TestOrderByPathLengthAsc(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	ordered := OrderByPathLen(ingressifyRules, true)
+	ordered := FromGeneric(OrderByPathLen(ToGeneric(ingressifyRules), true))
 	for i := 0; i < len(ordered)-1; i++ {
 		if len(ordered[i].Path) < len(ordered[i+1].Path) {
 			t.Errorf("Paths are not in ascending order, got: len(%s) < len(%s)", ordered[i].Path, ordered[i+1].Path)
@@ -168,10 +168,71 @@ func TestOrderByPathLengthAsc(t *testing.T) {
 func TestOrderByPathLengthDesc(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)
-	ordered := OrderByPathLen(ingressifyRules, false)
+	ordered := FromGeneric(OrderByPathLen(ToGeneric(ingressifyRules), false))
 	for i := 0; i < len(ordered)-1; i++ {
 		if len(ordered[i].Path) > len(ordered[i+1].Path) {
 			t.Errorf("Paths are not in descending order, got: len(%s) > len(%s)", ordered[i].Path, ordered[i+1].Path)
+		}
+	}
+}
+
+func TestFromGeneric(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	gen := make([]interface{}, len(ingressifyRules))
+	for i := range ingressifyRules {
+		gen[i] = ingressifyRules[i]
+	}
+	fromGen := FromGeneric(gen)
+	// len should be equal
+	if len(fromGen) != len(ingressifyRules) {
+		t.Errorf("Length should be equal, got: %d, expected: %d", len(fromGen), len(ingressifyRules))
+	}
+	// all rules should be the same on both arrays
+	for i := range fromGen {
+		if fromGen[i].Hash != ingressifyRules[i].Hash {
+			t.Errorf("Missing rule after applying FromGeneric, got hash: %d, expected hash: %d", ingressifyRules[i].Hash, fromGen[i].Hash)
+		}
+	}
+}
+
+func TestToGeneric(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	gen := ToGeneric(ingressifyRules)
+	// len should be equal
+	if len(gen) != len(ingressifyRules) {
+		t.Errorf("Length should be equal, got: %d, expected: %d", len(gen), len(ingressifyRules))
+	}
+	// underlying type must be IngressifyRule
+	for i := range gen {
+		if reflect.TypeOf(gen[i]) != reflect.TypeOf(ingressifyRules[i]) {
+			t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[i]), reflect.TypeOf(ingressifyRules[i]))
+		}
+	}
+}
+
+func TestToGenericMap(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	m := make(map[string][]IngressifyRule)
+	for _, k := range ingressifyRules {
+		key := string(k.Hash)
+		if _, ok := m[key]; ok {
+			m[key] = append(m[key], k)
+		} else {
+			m[key] = []IngressifyRule{k}
+		}
+	}
+	gen := ToGenericMap(m)
+	if len(gen) != len(m) {
+		t.Errorf("Maps should have the same length, got: %d, expected: %d", len(gen), len(m))
+	}
+	for k := range m {
+		for i := range gen[k] {
+			if reflect.TypeOf(gen[k][i]) != reflect.TypeOf(m[k][i]) {
+				t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[k][i]), reflect.TypeOf(m[k][i]))
+			}
 		}
 	}
 }

--- a/data_test.go
+++ b/data_test.go
@@ -53,6 +53,45 @@ func TestToIngressifyRule(t *testing.T) {
 	}
 }
 
+func TestAsMap(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	m := make(map[string][]IngressifyRule)
+	for _, k := range ingressifyRules {
+		key := string(k.Hash)
+		if _, ok := m[key]; ok {
+			m[key] = append(m[key], k)
+		} else {
+			m[key] = []IngressifyRule{k}
+		}
+	}
+	gen := AsMap(m)
+	if len(gen) != len(m) {
+		t.Errorf("Maps should have the same length, got: %d, expected: %d", len(gen), len(m))
+	}
+	for k := range gen {
+		if reflect.TypeOf(gen[k]) != reflect.TypeOf(m[k]) {
+			t.Errorf("Underlying types don't match, got: %s, expected: %s", reflect.TypeOf(gen[k]), reflect.TypeOf(m[k]))
+		}
+	}
+}
+
+func TestAsSlice(t *testing.T) {
+	testRules := generateRules("./examples/ingressList.json")
+	ingressifyRules := ToIngressifyRule(&testRules)
+	gen := AsSlice(ingressifyRules)
+	// len should be equal
+	if len(gen) != len(ingressifyRules) {
+		t.Errorf("Length should be equal, got: %d, expected: %d", len(gen), len(ingressifyRules))
+	}
+	// underlying type must be IngressifyRule
+	for i := range gen {
+		if reflect.TypeOf(gen[i]) != reflect.TypeOf(ingressifyRules[i]) {
+			t.Errorf("Different types, got: %s, expected: %s", reflect.TypeOf(gen[i]), reflect.TypeOf(ingressifyRules[i]))
+		}
+	}
+}
+
 func TestGroupByHost(t *testing.T) {
 	testRules := generateRules("./examples/ingressList.json")
 	ingressifyRules := ToIngressifyRule(&testRules)

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/apex/log"
 	"github.com/pkg/errors"
+	tb "github.com/viant/toolbox"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -44,8 +45,8 @@ func main() {
 		"GroupByPath":    GroupByPath,
 		"GroupBySvcNs":   GroupBySvcNs,
 		"OrderByPathLen": OrderByPathLen,
-		"ToSprigList":    ToSprigList,
-		"ToSprigDict":    ToSprigDict,
+		"AsMap":          tb.AsMap,
+		"AsSlice":        tb.AsSlice,
 	}
 
 	clientset, err := GetKubeClient(config.Kubeconfig)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/apex/log"
 	"github.com/pkg/errors"
-	tb "github.com/viant/toolbox"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -45,8 +44,8 @@ func main() {
 		"GroupByPath":    GroupByPath,
 		"GroupBySvcNs":   GroupBySvcNs,
 		"OrderByPathLen": OrderByPathLen,
-		"AsMap":          tb.AsMap,
-		"AsSlice":        tb.AsSlice,
+		"AsMap":          AsMap,
+		"AsSlice":        AsSlice,
 	}
 
 	clientset, err := GetKubeClient(config.Kubeconfig)

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ func main() {
 		"GroupByPath":    GroupByPath,
 		"GroupBySvcNs":   GroupBySvcNs,
 		"OrderByPathLen": OrderByPathLen,
+		"ToSprigList":    ToSprigList,
+		"ToSprigDict":    ToSprigDict,
 	}
 
 	clientset, err := GetKubeClient(config.Kubeconfig)
@@ -151,7 +153,7 @@ func render(outPath string, clientset *kubernetes.Clientset, tmpl *template.Temp
 	if err != nil {
 		return err
 	}
-	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
+	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, outPath, cxt)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func render(outPath string, clientset *kubernetes.Clientset, tmpl *template.Temp
 	if err != nil {
 		return err
 	}
-	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
+	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
 	err = RenderTemplate(tmpl, outPath, cxt)
 	if err != nil {
 		return err

--- a/render_test.go
+++ b/render_test.go
@@ -30,7 +30,7 @@ func runRenderFor(router string) (actual string, expected string) {
 		panic(err)
 	}
 
-	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
+	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
 	if err != nil {
 		panic(err)

--- a/render_test.go
+++ b/render_test.go
@@ -30,7 +30,7 @@ func runRenderFor(router string) (actual string, expected string) {
 		panic(err)
 	}
 
-	cxt := ICxt{IngRules: ToIngressifyRule(irules)}
+	cxt := ICxt{IngRules: ToGeneric(ToIngressifyRule(irules))}
 	err = RenderTemplate(tmpl, config.OutTemplate, cxt)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
We add `AsSlice` and `AsMap` functions as helpers to turn any array/map into generic data structures that Sprig can use. 

This decision is adopted since, turning everything into generics is quite involved and we don't know for sure if we actually need it ! When people need to use any of the Sprig functions they can simply do like: 
```
{{ $a := GroupByHost .IngRules }}
{{ range $k, $v := range $a }}
{{ AsSlice $v | first }}
{{ end }}
```
or 
```
vars := map[string][]int{"Name": []int{1, 2, 3, 4}}
tpl := `Hello {{ AsMap . | pluck "Name" | first | AsSlice | first }}`
```