### PR TITLE
Remove coverage upload script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ script:
 - bin/test.sh
 - VERSION="$TRAVIS_TAG" bin/cross-compile.sh
 after_success:
-- mv overalls.coverprofile coverage.txt
-- bash <(curl -s https://codecov.io/bash) -t 1e11888e-6fb8-458d-b0d9-515b49b74529
 - bin/release-latest.sh
 deploy:
   provider: releases


### PR DESCRIPTION
The upload bash script was compromised on Coverage's side
and our company has ceased to use this service.

Don't run this script.